### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -19,6 +19,8 @@ env:
 
 jobs:
   devcontainer:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       CHEF_LICENSE: accept-no-persist


### PR DESCRIPTION
Potential fix for [https://github.com/sommerfeld-io/configs-homelab/security/code-scanning/7](https://github.com/sommerfeld-io/configs-homelab/security/code-scanning/7)

To fix the problem, add a `permissions` block to the `devcontainer` job (or at the workflow root if all jobs should inherit it) specifying the minimum required permissions. Since the job only checks out code and does not write to the repository or interact with issues/pull requests, the minimal permission of `contents: read` is sufficient. This can be added directly under the `devcontainer:` job definition (just before `runs-on:`).

**How to fix:**  
- In `.github/workflows/dev-environment.yml`, locate the `devcontainer` job definition.
- Add the following block under `devcontainer:`:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
